### PR TITLE
DE107070-Updated for side menu icon fix.

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -439,10 +439,16 @@ static char ja_kvoContext;
                 buttonController = [nav.viewControllers objectAtIndex:0];
             }
         }
-        if (!buttonController.navigationItem.leftBarButtonItem) {   
-            buttonController.navigationItem.leftBarButtonItem = [self leftButtonForCenterPanel];
+
+        if (!buttonController.navigationItem.leftBarButtonItem) {
+            UIBarButtonItem *placeHolderBarButtonItem = [UIBarButtonItem new];
+            if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+                buttonController.navigationItem.leftBarButtonItem = [self leftButtonForCenterPanel];
+            } else {
+                buttonController.navigationItem.leftBarButtonItems = @[placeHolderBarButtonItem, [self leftButtonForCenterPanel]];
+            }
         }
-    }	
+    }
 }
 
 #pragma mark - Gesture Recognizer Delegate


### PR DESCRIPTION
Goal:
Made change on the side menu to fix the icon for IPhone

Rally : DE107070

ℹ️ Changes:

Changed IPHone left button to apply constraints.
ℹ️ Acceptance criteria:

menu icon image should stay aligned with it's tap target and both should be 16px from the left